### PR TITLE
Update pngJS dep + bump version

### DIFF
--- a/screenshots-diff/package-lock.json
+++ b/screenshots-diff/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "screenshots-diff",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/jpeg-js": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@types/jpeg-js/-/jpeg-js-0.3.7.tgz",
-      "integrity": "sha512-v3FEzt2TXOOIgvwwOqMoeEhqYqUoK4wcV/K7JbKj8CzwDE9sSuor8EZpSJKaOnuEtyO0W+Nd2uKk8MbtusYpEg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jpeg-js/-/jpeg-js-0.3.0.tgz",
+      "integrity": "sha512-S6bajx+UpnHzh/nFgGOJ8uvDCElV+eGvljDpJKHK2FW53erZxhX+CitbUFbrsmZi1h/I+DzvGp0MWyKl3dF1yw==",
       "dev": true,
       "requires": {
-        "jpeg-js": "*"
+        "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "10.14.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.21.tgz",
-      "integrity": "sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ==",
+      "version": "10.14.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
+      "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
       "dev": true
     },
     "@types/pngjs": {
@@ -34,9 +34,9 @@
       "integrity": "sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w=="
     },
     "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "typescript": {
       "version": "3.5.3",

--- a/screenshots-diff/package.json
+++ b/screenshots-diff/package.json
@@ -13,13 +13,13 @@
     "diff",
     "visual regression"
   ],
-  "version": "1.2.3",
+  "version": "1.2.5",
   "scripts": {
     "build": "tsc --project tsconfig.json"
   },
   "dependencies": {
     "jpeg-js": "0.4.0",
-    "pngjs": "3.4.0"
+    "pngjs": "5.0.0"
   },
   "devDependencies": {
     "@types/jpeg-js": "^0.3.0",

--- a/screenshots-diff/yarn.lock
+++ b/screenshots-diff/yarn.lock
@@ -31,10 +31,10 @@ jpeg-js@0.4.0:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.0.tgz#39adab7245b6d11e918ba5d4b49263ff2fc6a2f9"
   integrity sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w==
 
-pngjs@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
-  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+pngjs@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 typescript@3.5.3:
   version "3.5.3"


### PR DESCRIPTION
Update PNGjs dependency
Bump version to 1.2.5 ( we already published 1.2.4 with earlier version of PNGjs )
